### PR TITLE
fix(free-disk-space): shell script formatting

### DIFF
--- a/free-disk-space/action.yaml
+++ b/free-disk-space/action.yaml
@@ -95,8 +95,8 @@ runs:
     - if: ${{ inputs.misc-packages == 'true' }}
       run: |
         sudo apt-get remove -y \
-          azure-cli google-cloud-sdk
-          google-chrome-stable firefox
+          azure-cli google-cloud-sdk \
+          google-chrome-stable firefox \
           powershell mono-devel libgl1-mesa-dri
         sudo apt-get autoremove -y
         sudo apt-get clean


### PR DESCRIPTION
Add proper line continuation backslashes in the
misc-packages removal step.

Fixes #59