### PR TITLE
retry merge on base branch race

### DIFF
--- a/pr/merge/README.md
+++ b/pr/merge/README.md
@@ -13,6 +13,8 @@ Automatically merge a pull request.
 | `merge-method` | <p>Merge method (merge, squash, rebase).</p> | `false` | `squash` |
 | `delete-branch` | <p>Delete branch after merge.</p> | `false` | `true` |
 | `auto` | <p>Enable GitHub auto-merge (automatically merge ONLY after necessary requirements are met).</p> | `false` | `true` |
+| `max-retries` | <p>Maximum number of merge attempts when the base branch is modified by a parallel merge.</p> | `false` | `3` |
+| `retry-delay` | <p>Initial delay in seconds between retries (doubles exponentially each attempt).</p> | `false` | `5` |
 
 
 ## Outputs
@@ -73,6 +75,18 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: true
+
+    max-retries:
+    # Maximum number of merge attempts when the base branch is modified by a parallel merge.
+    #
+    # Required: false
+    # Default: 3
+
+    retry-delay:
+    # Initial delay in seconds between retries (doubles exponentially each attempt).
+    #
+    # Required: false
+    # Default: 5
 ```
 
 

--- a/pr/merge/README.md
+++ b/pr/merge/README.md
@@ -13,8 +13,8 @@ Automatically merge a pull request.
 | `merge-method` | <p>Merge method (merge, squash, rebase).</p> | `false` | `squash` |
 | `delete-branch` | <p>Delete branch after merge.</p> | `false` | `true` |
 | `auto` | <p>Enable GitHub auto-merge (automatically merge ONLY after necessary requirements are met).</p> | `false` | `true` |
-| `max-retries` | <p>Maximum number of merge attempts when the base branch is modified by a parallel merge.</p> | `false` | `3` |
-| `retry-delay` | <p>Initial delay in seconds between retries (doubles exponentially each attempt).</p> | `false` | `5` |
+| `max-retries` | <p>Maximum number of merge attempts for transient merge failures.</p> | `false` | `3` |
+| `retry-delay` | <p>Initial delay in seconds before retrying a transient merge failure (doubles exponentially after each retry).</p> | `false` | `5` |
 
 
 ## Outputs
@@ -77,13 +77,13 @@ This action is a `composite` action.
     # Default: true
 
     max-retries:
-    # Maximum number of merge attempts when the base branch is modified by a parallel merge.
+    # Maximum number of merge attempts for transient merge failures such as parallel base branch updates, network issues, or GitHub rate limits.
     #
     # Required: false
     # Default: 3
 
     retry-delay:
-    # Initial delay in seconds between retries (doubles exponentially each attempt).
+    # Initial delay in seconds before retrying a transient merge failure (doubles exponentially after each retry).
     #
     # Required: false
     # Default: 5

--- a/pr/merge/action.yaml
+++ b/pr/merge/action.yaml
@@ -30,11 +30,11 @@ inputs:
     required: false
     default: "true"
   max-retries:
-    description: "Maximum number of merge attempts when the base branch is modified by a parallel merge."
+    description: "Maximum number of merge attempts for transient merge failures."
     required: false
     default: "3"
   retry-delay:
-    description: "Initial delay in seconds between retries (doubles exponentially each attempt)."
+    description: "Initial delay in seconds before retrying a transient merge failure (doubles exponentially after each retry)."
     required: false
     default: "5"
 

--- a/pr/merge/action.yaml
+++ b/pr/merge/action.yaml
@@ -29,6 +29,14 @@ inputs:
     description: "Enable GitHub auto-merge (automatically merge ONLY after necessary requirements are met)."
     required: false
     default: "true"
+  max-retries:
+    description: "Maximum number of merge attempts when the base branch is modified by a parallel merge."
+    required: false
+    default: "3"
+  retry-delay:
+    description: "Initial delay in seconds between retries (doubles exponentially each attempt)."
+    required: false
+    default: "5"
 
 outputs:
   merged:
@@ -64,6 +72,8 @@ runs:
         INPUT_MERGE_METHOD: ${{ inputs.merge-method }}
         INPUT_DELETE_BRANCH: ${{ inputs.delete-branch }}
         INPUT_AUTO: ${{ inputs.auto }}
+        INPUT_MAX_RETRIES: ${{ inputs.max-retries }}
+        INPUT_RETRY_DELAY: ${{ inputs.retry-delay }}
         OUTPUT_PR_NUMBER: ${{ steps.pr.outputs.number }}
       run: $GITHUB_ACTION_PATH/merge.sh
     

--- a/pr/merge/merge.sh
+++ b/pr/merge/merge.sh
@@ -4,6 +4,35 @@ set -euo pipefail
 
 source <(curl -fsSL "https://github.com/projectdiscovery/actions/raw/refs/heads/dotfiles/.bash_aliases")
 
+is_transient() {
+    local err="$1" pat rc=1
+    shopt -s nocasematch
+    for pat in "${TRANSIENT_PATTERNS[@]}"; do
+        if [[ "${err}" == *"${pat}"* ]]; then
+            rc=0
+            break
+        fi
+    done
+    shopt -u nocasematch
+    return "${rc}"
+}
+
+# Patterns that indicate a transient failure worth retrying. Anything else
+# (merge conflict, branch protection, missing review, etc.) is a real failure
+# and we fail fast instead of burning retries.
+TRANSIENT_PATTERNS=(
+    "Base branch was modified"
+    "HTTP 5"
+    "rate limit"
+    "secondary rate limit"
+    "i/o timeout"
+    "connection reset"
+    "connection refused"
+    "could not resolve host"
+    "TLS handshake timeout"
+    "EOF"
+)
+
 PR_NUMBER="${INPUT_PR_NUMBER}"
 if [[ -z "${PR_NUMBER}" ]]; then
     PR_NUMBER="${OUTPUT_PR_NUMBER}"
@@ -28,35 +57,6 @@ fi
 MAX_ATTEMPTS="${INPUT_MAX_RETRIES:-3}"
 DELAY="${INPUT_RETRY_DELAY:-5}"
 
-# Patterns that indicate a transient failure worth retrying. Anything
-# else (merge conflict, branch protection, missing review, etc.) is a
-# real failure and we fail fast instead of burning retries.
-TRANSIENT_PATTERNS=(
-    "Base branch was modified"
-    "HTTP 5"
-    "rate limit"
-    "secondary rate limit"
-    "i/o timeout"
-    "connection reset"
-    "connection refused"
-    "could not resolve host"
-    "TLS handshake timeout"
-    "EOF"
-)
-
-is_transient() {
-    local err="$1" pat rc=1
-    shopt -s nocasematch
-    for pat in "${TRANSIENT_PATTERNS[@]}"; do
-        if [[ "${err}" == *"${pat}"* ]]; then
-            rc=0
-            break
-        fi
-    done
-    shopt -u nocasematch
-    return "${rc}"
-}
-
 attempt=1
 while :; do
     if STDERR_OUTPUT=$(gh pr merge "${PR_NUMBER}" \
@@ -74,7 +74,7 @@ while :; do
     fi
 
     if is_transient "${STDERR_OUTPUT}" && (( attempt < MAX_ATTEMPTS )); then
-        echo "::warning::PR #${PR_NUMBER}: transient merge failure (attempt ${attempt}/${MAX_ATTEMPTS}). Retrying in ${DELAY}s..."
+        printWarning "PR #${PR_NUMBER}: transient merge failure (attempt ${attempt}/${MAX_ATTEMPTS}). Retrying in ${DELAY}s..."
         echo "${STDERR_OUTPUT}" >&2
         sleep "${DELAY}"
         DELAY=$(( DELAY * 2 ))

--- a/pr/merge/merge.sh
+++ b/pr/merge/merge.sh
@@ -25,16 +25,34 @@ if [[ "${INPUT_AUTO:-}" == "true" ]]; then
     AUTO_FLAG="--auto"
 fi
 
-gh pr merge "${PR_NUMBER}" \
-    --repo "${INPUT_REPOSITORY}" \
-    --${INPUT_MERGE_METHOD} \
-    ${AUTO_FLAG} \
-    ${DELETE_FLAG} \
-    && {
-      echo "merged=true"
-      echo "pr-number=${PR_NUMBER}"
-    } >> "${GITHUB_OUTPUT}" \
-    || {
-      printErrorWithExit "Failed to merge PR #${PR_NUMBER}." 1
-    }
+MAX_ATTEMPTS="${INPUT_MAX_RETRIES:-3}"
+DELAY="${INPUT_RETRY_DELAY:-5}"
 
+attempt=1
+while :; do
+    if STDERR_OUTPUT=$(gh pr merge "${PR_NUMBER}" \
+        --repo "${INPUT_REPOSITORY}" \
+        --${INPUT_MERGE_METHOD} \
+        ${AUTO_FLAG} \
+        ${DELETE_FLAG} \
+        2>&1); then
+        {
+            echo "merged=true"
+            echo "pr-number=${PR_NUMBER}"
+        } >> "${GITHUB_OUTPUT}"
+        echo "Successfully merged PR #${PR_NUMBER} (attempt ${attempt}/${MAX_ATTEMPTS})."
+        exit 0
+    fi
+
+    # Only retry on transient errors caused by a parallel merge advancing the base branch.
+    if [[ "${STDERR_OUTPUT}" == *"Base branch was modified"* ]] && (( attempt < MAX_ATTEMPTS )); then
+        echo "::warning::PR #${PR_NUMBER}: base branch was modified during merge (attempt ${attempt}/${MAX_ATTEMPTS}). Retrying in ${DELAY}s..."
+        sleep "${DELAY}"
+        DELAY=$(( DELAY * 2 ))
+        attempt=$(( attempt + 1 ))
+        continue
+    fi
+
+    echo "${STDERR_OUTPUT}" >&2
+    printErrorWithExit "Failed to merge PR #${PR_NUMBER} after ${attempt} attempt(s)." 1
+done

--- a/pr/merge/merge.sh
+++ b/pr/merge/merge.sh
@@ -28,6 +28,35 @@ fi
 MAX_ATTEMPTS="${INPUT_MAX_RETRIES:-3}"
 DELAY="${INPUT_RETRY_DELAY:-5}"
 
+# Patterns that indicate a transient failure worth retrying. Anything
+# else (merge conflict, branch protection, missing review, etc.) is a
+# real failure and we fail fast instead of burning retries.
+TRANSIENT_PATTERNS=(
+    "Base branch was modified"
+    "HTTP 5"
+    "rate limit"
+    "secondary rate limit"
+    "i/o timeout"
+    "connection reset"
+    "connection refused"
+    "could not resolve host"
+    "TLS handshake timeout"
+    "EOF"
+)
+
+is_transient() {
+    local err="$1" pat rc=1
+    shopt -s nocasematch
+    for pat in "${TRANSIENT_PATTERNS[@]}"; do
+        if [[ "${err}" == *"${pat}"* ]]; then
+            rc=0
+            break
+        fi
+    done
+    shopt -u nocasematch
+    return "${rc}"
+}
+
 attempt=1
 while :; do
     if STDERR_OUTPUT=$(gh pr merge "${PR_NUMBER}" \
@@ -44,9 +73,9 @@ while :; do
         exit 0
     fi
 
-    # Only retry on transient errors caused by a parallel merge advancing the base branch.
-    if [[ "${STDERR_OUTPUT}" == *"Base branch was modified"* ]] && (( attempt < MAX_ATTEMPTS )); then
-        echo "::warning::PR #${PR_NUMBER}: base branch was modified during merge (attempt ${attempt}/${MAX_ATTEMPTS}). Retrying in ${DELAY}s..."
+    if is_transient "${STDERR_OUTPUT}" && (( attempt < MAX_ATTEMPTS )); then
+        echo "::warning::PR #${PR_NUMBER}: transient merge failure (attempt ${attempt}/${MAX_ATTEMPTS}). Retrying in ${DELAY}s..."
+        echo "${STDERR_OUTPUT}" >&2
         sleep "${DELAY}"
         DELAY=$(( DELAY * 2 ))
         attempt=$(( attempt + 1 ))


### PR DESCRIPTION
Retries `gh pr merge` when GitHub returns `Base branch was modified` (parallel merge advancing the base). Two new optional inputs: `max-retries` (default 3) and `retry-delay` (default 5s, exponential).