### PR TITLE
feat(setup/go): use fork with alt .mod support

### DIFF
--- a/setup/go/action.yaml
+++ b/setup/go/action.yaml
@@ -5,7 +5,7 @@ inputs:
   go-version:
     description: 'The Go version to download (if necessary) and use. Supports semver spec and ranges. Be sure to enclose this option in single quotation marks.'
   go-version-file:
-    description: 'Path to the go.mod, go.work, .go-version, or .tool-versions file.'
+    description: 'Path to the go.mod, go.work, alternate .mod, .go-version, or .tool-versions file.'
   check-latest:
     description: 'Set this option to true if you want the action to always check for the latest available version that satisfies the version spec'
     default: 'true'
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v6
+    - uses: dwisiswant0/setup-go@main
       with:
         go-version: ${{ inputs.go-version }}
         go-version-file: ${{ inputs.go-version == '' && (inputs.go-version-file || 'go.mod') || inputs.go-version-file }}


### PR DESCRIPTION
`actions/setup-go` action only treats go.{mod,work}
as Go directive files. Alternate modfiles such as
go.tool.mod fall back to the raw file contents,
which breaks `go-version-file` resolution.

Switch to `dwisiswant0/setup-go@main` to pick up
alt .mod parsing for toolchain/go directives.

Closes #94