### PR TITLE
feat(goreleaser): use build mode for snapshot runs

### DIFF
--- a/goreleaser/README.md
+++ b/goreleaser/README.md
@@ -6,7 +6,7 @@ Run GoReleaser
 
 | name | description | required | default |
 | --- | --- | --- | --- |
-| `release` | <p>Run without snapshot</p> | `false` | `false` |
+| `release` | <p>Run a full release instead of a snapshot binary build</p> | `false` | `false` |
 | `workdir` | <p>Working directory</p> | `false` | `.` |
 | `args` | <p>Run with arguments</p> | `false` | `""` |
 
@@ -21,7 +21,7 @@ This action is a `composite` action.
 - uses: projectdiscovery/actions/goreleaser@v1
   with:
     release:
-    # Run without snapshot
+    # Run a full release instead of a snapshot binary build
     #
     # Required: false
     # Default: false

--- a/goreleaser/action.yaml
+++ b/goreleaser/action.yaml
@@ -3,7 +3,7 @@ description: 'Run GoReleaser'
 
 inputs:
   release:
-    description: 'Run without snapshot'
+    description: 'Run a full release instead of a snapshot binary build'
     required: false
     default: 'false'
   workdir:
@@ -18,7 +18,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: projectdiscovery/actions/free-disk-space@v1
+    - if: inputs.release == 'true'
+      uses: projectdiscovery/actions/free-disk-space@v1
       with:
         llvm: 'false'
         php: 'false'
@@ -27,12 +28,15 @@ runs:
         misc-packages: 'false'
         docker-images: 'false'
         tools-cache: 'false'
-    - if: runner.os == 'Linux'
+    - if: inputs.release == 'true' && runner.os == 'Linux'
       uses: docker/setup-qemu-action@v4
-    - if: runner.os == 'Linux'
+    - if: inputs.release == 'true' && runner.os == 'Linux'
       uses: docker/setup-buildx-action@v4
     - uses: goreleaser/goreleaser-action@v7
       with:
         version: 'latest'
-        args: release --skip=validate --clean ${{ inputs.release != 'true' && '--snapshot' || '' }} ${{ inputs.args }}
+        args: >-
+          ${{ inputs.release == 'true' && 'release --skip=validate' || 'build --snapshot' }}
+          --clean
+          ${{ inputs.args }}
         workdir: '${{ inputs.workdir }}'


### PR DESCRIPTION
Use goreleaser build for non-release invocations
and skip the disk, QEMU, and Buildx setup reserved
for full releases. This lets callers append
`--single-target` while keeping the release path
unchanged.